### PR TITLE
Update stylesheet for dark mode text and make logo clickable

### DIFF
--- a/your-tribe-fl/src/lib/components/Spinning.svelte
+++ b/your-tribe-fl/src/lib/components/Spinning.svelte
@@ -57,14 +57,14 @@
      Circular text container
   --------------------------------------------- */
   .seal {
-    position: relative;
-    width: var(--size);
-    height: var(--size);
-    border-radius: 50%;
-    animation: rotation var(--speed) linear infinite; /* continuous rotation */
-    font-family: 'Montserrat', sans-serif;
-    font-size: var(--font);
-    color: var(--color-text-dark);
+  position: relative;
+  width: var(--size);
+  height: var(--size);
+  border-radius: 50%;
+  animation: rotation var(--speed) linear infinite; /* continuous rotation */
+  font-family: 'Montserrat', sans-serif;
+  font-size: var(--font);
+  color: var(--text-color); /* <-- gebruik de globale variabele */
   }
   /* ---------------------------------------------
      Individual characters positioned around the circle

--- a/your-tribe-fl/src/lib/components/header.svelte
+++ b/your-tribe-fl/src/lib/components/header.svelte
@@ -13,7 +13,7 @@
   // Function to toggle between light and dark theme
   function toggleTheme() {
     isDark = !isDark;
-    // Add bg-dark class if isDark is true, otherwise bg-light
+  // Add bg-dark class if isDark is true, otherwise bg-light
     document.body.classList.toggle('bg-dark', isDark);
     document.body.classList.toggle('bg-light', !isDark);
   }
@@ -35,10 +35,12 @@
 </script>
 
 <header class="header">
-  <!-- Left side of the header: logo -->
-  <div class="header-left">
+<!-- Left side of the header: logo -->
+<div class="header-left">
+  <a href="/">
     <img src={logo} alt="Logo" class="logo" />
-  </div>
+  </a>
+</div>
 
   <!-- Center of the header: title -->
   <div class="header-center">

--- a/your-tribe-fl/static/stylesheet.css
+++ b/your-tribe-fl/static/stylesheet.css
@@ -1,22 +1,23 @@
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600&display=swap');
 
+/* ------------------ Root Variables ------------------ */
 :root {
-  /* ------------------ Background ------------------ */
+  /* Background */
   --color-bg-dark: #180E01;
   --color-bg-light: #CEC0AE;
 
-  /* ------------------ Text ------------------ */
+  /* Text */
   --color-text-dark: #180E01;
   --color-text-light: #CEC0AE;
   --color-white-text: #fff;
   --btn-weight: 600;
 
-  /* ------------------ Button System ------------------ */
+  /* Buttons */
   --btn-radius: 999px;
   --btn-padding: 0.75rem 1.5rem;
-  --btn-font: 'montserrat', sans-serif;
+  --btn-font: 'Montserrat', sans-serif;
 
-  /* ------------------ Text Size ------------------ */
+  /* Text Sizes */
   --text-size-xs: clamp(0.75rem, 1.5vw, 12px);
   --text-size-sm: clamp(0.875rem, 1.75vw, 14px);
   --text-size-md: clamp(1rem, 2vw, 16px);
@@ -24,44 +25,47 @@
   --text-size-xl: clamp(1.25rem, 2.5vw, 20px);
 }
 
+/* ------------------ Body Modes ------------------ */
+body.bg-light {
+  --bg-color: var(--color-bg-light);
+  --text-color: var(--color-text-dark);
+}
+
+body.bg-dark {
+  --bg-color: var(--color-bg-dark);
+  --text-color: var(--color-white-text);
+}
+
+/* ------------------ Global Styles ------------------ */
 body {
-  background-color: var(--color-bg-light);
+  background-color: var(--bg-color);
+  color: var(--text-color);
   font-family: var(--btn-font);
+  transition: background-color 0.3s ease, color 0.3s ease;
 }
 
 a {
+  color: var(--text-color);
   text-decoration: none;
 }
 
-/* ------------------ Background Classes ------------------ */
-.bg-dark {
-  background-color: var(--color-bg-dark);
-}
-
-.bg-light {
-  background-color: var(--color-bg-light);
-}
-
-/* ------------------ Text Classes ------------------ */
-.text-dark {
-  color: var(--color-text-dark);
-}
-
-.text-light {
-  color: var(--color-text-light);
-}
+/* ------------------ Background & Text Classes ------------------ */
+.bg-dark { background-color: var(--color-bg-dark); }
+.bg-light { background-color: var(--color-bg-light); }
+.text-dark { color: var(--color-text-dark); }
+.text-light { color: var(--color-text-light); }
 
 /* ------------------ Typography ------------------ */
 .text-h1 {
   font-family: var(--btn-font);
-  font-size: clamp(var(--size-m), 5vw, 48px);
+  font-size: clamp(1rem, 5vw, 48px);
   font-weight: 500;
   margin-bottom: 1rem;
 }
- 
+
 .text-p {
   font-family: var(--btn-font);
-  font-size: clamp(var(--size-xs), 2.5vw, 20px);
+  font-size: clamp(0.75rem, 2.5vw, 20px);
   font-weight: 400;
   margin-bottom: 1rem;
 }
@@ -71,14 +75,12 @@ a {
   display: inline-block;
   position: relative;
   z-index: 1;
-
   padding: var(--btn-padding);
   border-radius: var(--btn-radius);
   font-family: var(--btn-font);
   font-weight: var(--btn-weight);
   text-align: center;
   cursor: pointer;
-  /* color: var(--color-text-dark); */
 
   /* Liquid Glass Effect */
   background: rgba(255, 255, 255, 0.2);
@@ -89,7 +91,6 @@ a {
   -webkit-backdrop-filter: blur(10px);
 }
 
-/* Tint overlay */
 .btn::before {
   content: "";
   position: absolute;
@@ -99,18 +100,16 @@ a {
   z-index: 0;
 }
 
-/* Subtle highlights */
 .btn::after {
   content: "";
   position: absolute;
   inset: 0;
   border-radius: inherit;
   box-shadow: inset 2px 2px 2px rgba(255, 255, 255, 0.5),
-  inset -1px -1px 2px rgba(255, 255, 255, 0.3);
+              inset -1px -1px 2px rgba(255, 255, 255, 0.3);
   z-index: 0;
 }
 
-/* Hover effect */
 .btn:hover {
   background: rgba(255, 255, 255, 0.3);
   transform: scale(1.03);


### PR DESCRIPTION
## What does this change?

Resolves issues #29, #41, #36, #5

* Adjusted styles so all text displays in white in dark mode.
* Made the site logo clickable, linking to the homepage.

[[Livesite](https://chatgpt.com/c/68cc01bd-d548-8328-86ff-c006a89e609c#)


<img width="1866" height="891" alt="image" src="https://github.com/user-attachments/assets/f6c22593-39cb-4a66-a12b-5b6cea0ba278" />

<img width="254" height="559" alt="image" src="https://github.com/user-attachments/assets/38bd5f76-02f9-4415-82b4-1255b84f6bd4" />


## How Has This Been Tested?

* Responsive design test across multiple devices and screen sizes.

## How to Review

* Run the site locally through my branch and review if it works
* Check the code structure to ensure consistency and proper use of components and styling.

